### PR TITLE
Standardizing Windows user data path

### DIFF
--- a/src/ansys/tools/path/__init__.py
+++ b/src/ansys/tools/path/__init__.py
@@ -13,6 +13,7 @@ __version__ = importlib_metadata.version(__name__.replace(".", "-"))
 
 
 from ansys.tools.path.path import (
+    SETTINGS_DIR,
     SUPPORTED_ANSYS_VERSIONS,
     change_default_mapdl_path,
     change_default_mechanical_path,

--- a/src/ansys/tools/path/path.py
+++ b/src/ansys/tools/path/path.py
@@ -578,7 +578,7 @@ def save_mapdl_path(exe_loc=None, allow_prompt=True) -> str:
         >>> from ansys.tools.path import SETTINGS_DIR
         >>> import os
         >>> print(os.path.join(SETTINGS_DIR, "config.txt"))
-        C:/Users/[username]]/AppData/Local/Ansys/ansys_tools_path/config.txt
+        C:/Users/[username]/AppData/Local/Ansys/ansys_tools_path/config.txt
 
     Examples
     --------

--- a/src/ansys/tools/path/path.py
+++ b/src/ansys/tools/path/path.py
@@ -50,7 +50,7 @@ else:
     PRODUCT_EXE_INFO["mechanical"]["pattern"] = ".workbench"
 
 # settings directory
-SETTINGS_DIR = appdirs.user_data_dir("ansys_tools_path")
+SETTINGS_DIR = appdirs.user_data_dir(appname="ansys_tools_path", appauthor="Ansys")
 if not os.path.isdir(SETTINGS_DIR):  # pragma: no cover
     try:
         LOG.debug(f"Created settings directory: {SETTINGS_DIR}")
@@ -513,7 +513,7 @@ def save_mechanical_path(exe_loc=None, allow_prompt=True):  # pragma: no cover
         - User input
 
         If a path is supplied, this method performs some checks. If the
-        checks are aresuccessful, it writes this path to the configuration
+        checks are successful, it writes this path to the configuration
         file.
 
     Returns
@@ -523,15 +523,15 @@ def save_mechanical_path(exe_loc=None, allow_prompt=True):  # pragma: no cover
 
     Notes
     -----
-    The location of the configuration file (``config.txt``) can be found in
-    ``appdirs.user_data_dir("ansys_tools_path")``. For example:
+    The location of the configuration file ``config.txt`` can be found in
+    ``ansys.tools.path.SETTINGS_DIR``. For example:
 
     .. code:: pycon
 
-        >>> import appdirs
+        >>> from ansys.tools.path import SETTINGS_DIR
         >>> import os
-        >>> print(os.path.join(appdirs.user_data_dir("ansys_tools_path"), "config.txt"))
-        C:/Users/[username]]/AppData/Local/ansys_tools_path/ansys_tools_path/config.txt
+        >>> print(os.path.join(SETTINGS_DIR, "config.txt"))
+        C:/Users/[username]]/AppData/Local/Ansys/ansys_tools_path/config.txt
 
     You can change the default for the ``exe_loc`` parameter either by modifying the
     ``config.txt`` file or by running this code:
@@ -570,15 +570,15 @@ def save_mapdl_path(exe_loc=None, allow_prompt=True) -> str:
 
     Notes
     -----
-    The configuration file location (``config.txt``) can be found in
-    ``appdirs.user_data_dir("ansys_tools_path")``. For example:
+    The location of the configuration file ``config.txt`` can be found in
+    ``ansys.tools.path.SETTINGS_DIR``. For example:
 
     .. code:: pycon
 
-        >>> import appdirs
+        >>> from ansys.tools.path import SETTINGS_DIR
         >>> import os
-        >>> print(os.path.join(appdirs.user_data_dir("ansys_tools_path"), "config.txt"))
-        C:/Users/user/AppData/Local/ansys_tools_path/ansys_tools_path/config.txt
+        >>> print(os.path.join(SETTINGS_DIR, "config.txt"))
+        C:/Users/[username]]/AppData/Local/Ansys/ansys_tools_path/config.txt
 
     Examples
     --------


### PR DESCRIPTION
Minor change

First described here https://github.com/ansys/pyfluent/issues/1588, and later https://github.com/ansys/pyprimemesh/issues/484

PRs: https://github.com/ansys/pyfluent/pull/1615, https://github.com/ansys/pymapdl/pull/2064, https://github.com/ansys/pyprimemesh/pull/485


1. Changes `SETTINGS_DIR` from `user_data_dir("ansys_tools_path")` which resolved to `%LocalAppData%\ansys_tools_path\ansys_tools_path` on Windows, to `user_data_dir(appname="ansys_tools_path", appauthor="Ansys")` which resolves to `%LocalAppData%\Ansys\ansys_tools_path`, same naming scheme as in PyFluent and the default Ansys Fluent Windows installation already creates the `%LocalAppData%\Ansys` root folder. <br> <br> This does not change anything in Linux as `appauthor` is unused on Linux. 
3. Exposing `SETTINGS_DIR` so that it can be used as `ansys.tools.path.SETTINGS_DIR` rather than `ansys.tools.path.path.SETTINGS_DIR` 
4. Reworked the examples for functions `save_mapdl_path` and `save_mechanical_path` to reflect these changes (no changes to the actual functions)

Note/food for thought: when `ansys.tools.path` is first imported, regardless of what the user is going to do, `SETTINGS_DIR` folder is immediately created, even if it is not going to be used. I would think this is probably unnecessary and you might want to change this (could break CI/tests though).