### PR TITLE
fix is_valid_executable_path() call for mechanical

### DIFF
--- a/src/ansys/tools/path/path.py
+++ b/src/ansys/tools/path/path.py
@@ -390,10 +390,6 @@ def _is_common_executable_path(product: PRODUCT_TYPE, exe_loc: str) -> bool:
         # in case the user has placed the installation folder inside a folder called for example (/ansys/v211)
         v_version = re.findall(r"v(\d\d\d)", exe_loc)
         ansys_version = re.findall(r"ansys(\d\d\d)", exe_loc, re.IGNORECASE)
-        import logging
-
-        logging.debug(v_version)
-        logging.debug(ansys_version)
         return (
             len(v_version) != 0
             and len(ansys_version) != 0

--- a/src/ansys/tools/path/path.py
+++ b/src/ansys/tools/path/path.py
@@ -511,9 +511,8 @@ def _save_path(
         _change_default_path(product, exe_loc)
         return exe_loc
 
-    if exe_loc is not None:
-        if is_valid_executable_path(product, exe_loc):
-            return exe_loc
+    if is_valid_executable_path(product, exe_loc):
+        return exe_loc
     if allow_prompt:
         exe_loc = _prompt_path(product)
     return exe_loc

--- a/src/ansys/tools/path/path.py
+++ b/src/ansys/tools/path/path.py
@@ -383,7 +383,7 @@ def _is_common_executable_path(product: str, exe_loc: str) -> bool:
         path = os.path.normpath(exe_loc)
         path = path.split(os.sep)
 
-        is_valid_path = is_valid_executable_path(exe_loc)
+        is_valid_path = is_valid_executable_path("mechanical", exe_loc)
 
         if is_windows():
             return (

--- a/src/ansys/tools/path/path.py
+++ b/src/ansys/tools/path/path.py
@@ -69,7 +69,7 @@ CONFIG_FILE = os.path.join(SETTINGS_DIR, CONFIG_FILE_NAME)
 
 def _get_installed_windows_versions(
     supported_versions: SUPPORTED_VERSIONS_TYPE = SUPPORTED_ANSYS_VERSIONS,
-):
+):  # pragma: no cover
     """Get the AWP_ROOT environment variable values for supported versions."""
 
     # The student version overwrites the AWP_ROOT env var
@@ -108,7 +108,7 @@ def _get_default_linux_base_path():
     return None  # pragma: no cover
 
 
-def _get_default_windows_base_path():
+def _get_default_windows_base_path():  # pragma: no cover
     """Get the default base path of the Ansys unified install on windows."""
 
     base_path = os.path.join(os.environ["PROGRAMFILES"], "ANSYS INC")
@@ -279,7 +279,7 @@ def find_mechanical(
     ans_path, version = _get_unified_install_base_for_version(version, supported_versions)
     if not ans_path or not version:
         return "", ""
-    if is_windows():
+    if is_windows():  # pragma: no cover
         mechanical_bin = os.path.join(ans_path, "aisol", "bin", "winx64", f"AnsysWBU.exe")
     else:
         mechanical_bin = os.path.join(ans_path, "aisol", ".workbench")
@@ -369,7 +369,7 @@ def is_valid_executable_path(product: PRODUCT_TYPE, exe_loc: str):
             and re.search(r"ansys\d\d\d", os.path.basename(os.path.normpath(exe_loc))) is not None
         )
     elif product == "mechanical":
-        if is_windows():
+        if is_windows():  # pragma: no cover
             return (
                 os.path.isfile(exe_loc)
                 and re.search("AnsysWBU.exe", os.path.basename(os.path.normpath(exe_loc)))
@@ -405,7 +405,7 @@ def _is_common_executable_path(product: PRODUCT_TYPE, exe_loc: str) -> bool:
 
         is_valid_path = is_valid_executable_path("mechanical", exe_loc)
 
-        if is_windows():
+        if is_windows():  # pragma: no cover
             return (
                 is_valid_path
                 and re.search(r"v\d\d\d", exe_loc) is not None

--- a/src/ansys/tools/path/path.py
+++ b/src/ansys/tools/path/path.py
@@ -386,23 +386,12 @@ def _is_common_executable_path(product: PRODUCT_TYPE, exe_loc: str) -> bool:
     if product == "mapdl":
         path = os.path.normpath(exe_loc)
         path = path.split(os.sep)
-        if (
-            re.search(r"v(\d\d\d)", exe_loc) is not None
-            and re.search(r"ansys(\d\d\d)", exe_loc) is not None
-        ):
-            equal_version = (
-                re.search(r"v(\d\d\d)", exe_loc)[1] == re.search(r"ansys(\d\d\d)", exe_loc)[1]
-            )
-        else:
-            equal_version = False
+        v_version = re.search(r"v(\d\d\d)", exe_loc)
+        ansys_version = re.search(r"ansys(\d\d\d)", exe_loc)
+        if v_version is not None and ansys_version is not None:
+            return is_valid_executable_path("mapdl", exe_loc) and "ansys" in path and "bin" in path
+        return False
 
-        return (
-            is_valid_executable_path("mapdl", exe_loc)
-            and re.search(r"v\d\d\d", exe_loc)
-            and "ansys" in path
-            and "bin" in path
-            and equal_version
-        )
     elif product == "mechanical":
         path = os.path.normpath(exe_loc)
         path = path.split(os.sep)
@@ -412,7 +401,7 @@ def _is_common_executable_path(product: PRODUCT_TYPE, exe_loc: str) -> bool:
         if is_windows():
             return (
                 is_valid_path
-                and re.search(r"v\d\d\d", exe_loc)
+                and re.search(r"v\d\d\d", exe_loc) is not None
                 and "aisol" in path
                 and "bin" in path
                 and "winx64" in path
@@ -421,7 +410,7 @@ def _is_common_executable_path(product: PRODUCT_TYPE, exe_loc: str) -> bool:
 
         return (
             is_valid_path
-            and re.search(r"v\d\d\d", exe_loc)
+            and re.search(r"v\d\d\d", exe_loc) is not None
             and "aisol" in path
             and ".workbench" in path
         )

--- a/src/ansys/tools/path/path.py
+++ b/src/ansys/tools/path/path.py
@@ -388,9 +388,14 @@ def _is_common_executable_path(product: PRODUCT_TYPE, exe_loc: str) -> bool:
         path = path.split(os.sep)
         v_version = re.search(r"v(\d\d\d)", exe_loc)
         ansys_version = re.search(r"ansys(\d\d\d)", exe_loc)
-        if v_version is not None and ansys_version is not None:
-            return is_valid_executable_path("mapdl", exe_loc) and "ansys" in path and "bin" in path
-        return False
+        return (
+            v_version is not None
+            and ansys_version is not None
+            and v_version[1] == ansys_version[1]
+            and is_valid_executable_path("mapdl", exe_loc)
+            and "ansys" in path
+            and "bin" in path
+        )
 
     elif product == "mechanical":
         path = os.path.normpath(exe_loc)

--- a/src/ansys/tools/path/path.py
+++ b/src/ansys/tools/path/path.py
@@ -386,12 +386,14 @@ def _is_common_executable_path(product: PRODUCT_TYPE, exe_loc: str) -> bool:
     if product == "mapdl":
         path = os.path.normpath(exe_loc)
         path = path.split(os.sep)
-        v_version = re.search(r"v(\d\d\d)", exe_loc)
-        ansys_version = re.search(r"ansys(\d\d\d)", exe_loc)
+        # Look for all v(\d\d\d) to catch the last one
+        # in case the user has placed the installation folder inside a folder called for example (/ansys/v211)
+        v_version = re.findall(r"v(\d\d\d)", exe_loc)
+        ansys_version = re.findall(r"ansys(\d\d\d)", exe_loc, re.IGNORECASE)
         return (
-            v_version is not None
-            and ansys_version is not None
-            and v_version[1] == ansys_version[1]
+            len(v_version) != 0
+            and len(ansys_version) != 0
+            and v_version[-1] == ansys_version[-1]
             and is_valid_executable_path("mapdl", exe_loc)
             and "ansys" in path
             and "bin" in path
@@ -408,9 +410,9 @@ def _is_common_executable_path(product: PRODUCT_TYPE, exe_loc: str) -> bool:
                 is_valid_path
                 and re.search(r"v\d\d\d", exe_loc) is not None
                 and "aisol" in path
-                and "bin" in path
+                and ("bin" in path or "Bin" in path)
                 and "winx64" in path
-                and "AnsysWBU.exe" in path
+                and ("AnsysWBU.exe" in path or "ANSYSWBU.exe" in path)
             )
 
         return (

--- a/src/ansys/tools/path/path.py
+++ b/src/ansys/tools/path/path.py
@@ -390,6 +390,10 @@ def _is_common_executable_path(product: PRODUCT_TYPE, exe_loc: str) -> bool:
         # in case the user has placed the installation folder inside a folder called for example (/ansys/v211)
         v_version = re.findall(r"v(\d\d\d)", exe_loc)
         ansys_version = re.findall(r"ansys(\d\d\d)", exe_loc, re.IGNORECASE)
+        import logging
+
+        logging.debug(v_version)
+        logging.debug(ansys_version)
         return (
             len(v_version) != 0
             and len(ansys_version) != 0

--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -1,4 +1,5 @@
 import os
+import sys
 
 import appdirs
 import pytest
@@ -24,17 +25,24 @@ paths = [
     pytest.param(("/usr/ansys_inc/ansys/bin/mapdl", 211), marks=pytest.mark.xfail),
 ]
 
-mapdl_executable_paths = [
-    ("C:/Program Files/ANSYS Inc/v202/ansys/bin/win64/ANSYS202.exe", True),
-    ("C:\\Program Files\\ANSYS Inc\\v202\\ansys\\bin\\win64\\ANSYS202.exe", True),
+linux_mapdl_executable_paths = [
     ("/usr/dir_v2019.1/slv/ansys_inc/v211/ansys/bin/ansys211", True),
     ("/usr/ansys_inc/v211/ansys/bin/mapdl", False),
 ]
 
-mechanical_executable_paths = [
+windows_mapdl_executable_paths = [
+    ("C:/Program Files/ANSYS Inc/v202/ansys/bin/win64/ANSYS202.exe", True),
+    ("C:\\Program Files\\ANSYS Inc\\v202\\ansys\\bin\\win64\\ANSYS202.exe", True),
+]
+
+windows_mechanical_executable_paths = [
     ("C:\\Program Files\\ANSYS Inc\\v221\\aisol\\Bin\\winx64\\ANSYSWBU.exe", True),
     ("C:/Program Files/ANSYS Inc/v221/aisol/Bin/winx64/ANSYSWBU.exe", True),
 ]
+
+# TODO: to fill with examples
+linux_mechanical_executable_paths = []
+
 
 skip_if_ansys_not_local = pytest.mark.skipif(
     os.environ.get("ANSYS_LOCAL", "").upper() != "TRUE", reason="Skipping on CI"
@@ -127,11 +135,27 @@ def mock_is_valid_executable_path(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr("ansys.tools.path.path.is_valid_executable_path", lambda _1, _2: True)
 
 
-@pytest.mark.parametrize("path,expected", mapdl_executable_paths)
-def test_is_common_executable_path_mapdl(mock_is_valid_executable_path, path, expected):
+@pytest.mark.skipif(sys.platform != "win32", reason="Test only available on windows")
+@pytest.mark.parametrize("path,expected", windows_mapdl_executable_paths)
+def test_windows_is_common_executable_path_mapdl(mock_is_valid_executable_path, path, expected):
     assert _is_common_executable_path("mapdl", path) == expected
 
 
-@pytest.mark.parametrize("path,expected", mechanical_executable_paths)
-def test_is_common_executable_path_mechanical(mock_is_valid_executable_path, path, expected):
+@pytest.mark.skipif(sys.platform != "linux", reason="Test only available on linux")
+@pytest.mark.parametrize("path,expected", linux_mapdl_executable_paths)
+def test_linux_is_common_executable_path_mapdl(mock_is_valid_executable_path, path, expected):
+    assert _is_common_executable_path("mapdl", path) == expected
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Test only available on windows")
+@pytest.mark.parametrize("path,expected", windows_mechanical_executable_paths)
+def test_windows_is_common_executable_path_mechanical(
+    mock_is_valid_executable_path, path, expected
+):
+    assert _is_common_executable_path("mechanical", path) == expected
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="Test only available on linux")
+@pytest.mark.parametrize("path,expected", linux_mechanical_executable_paths)
+def test_linux_is_common_executable_path_mechanical(mock_is_valid_executable_path, path, expected):
     assert _is_common_executable_path("mechanical", path) == expected

--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -123,7 +123,7 @@ def test_get_mapdl_path():
 
 
 @pytest.fixture
-def mock_is_valid_executable_path(monkeypatch):
+def mock_is_valid_executable_path(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr("ansys.tools.path.path.is_valid_executable_path", lambda _1, _2: True)
 
 

--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -7,6 +7,7 @@ from ansys.tools.path import find_mapdl
 from ansys.tools.path.path import (
     _check_uncommon_executable_path,
     _clear_config_file,
+    _is_common_executable_path,
     change_default_mapdl_path,
     get_available_ansys_installations,
     get_mapdl_path,
@@ -18,10 +19,22 @@ from ansys.tools.path.path import (
 paths = [
     ("/usr/dir_v2019.1/slv/ansys_inc/v211/ansys/bin/ansys211", 211),
     ("C:/Program Files/ANSYS Inc/v202/ansys/bin/win64/ANSYS202.exe", 202),
+    ("C:\\Program Files\\ANSYS Inc\\v202\\ansys\\bin\\win64\\ANSYS202.exe", 202),
     ("/usr/ansys_inc/v211/ansys/bin/mapdl", 211),
     pytest.param(("/usr/ansys_inc/ansys/bin/mapdl", 211), marks=pytest.mark.xfail),
 ]
 
+mapdl_executable_paths = [
+    ("C:/Program Files/ANSYS Inc/v202/ansys/bin/win64/ANSYS202.exe", True),
+    ("C:\\Program Files\\ANSYS Inc\\v202\\ansys\\bin\\win64\\ANSYS202.exe", True),
+    ("/usr/dir_v2019.1/slv/ansys_inc/v211/ansys/bin/ansys211", True),
+    ("/usr/ansys_inc/v211/ansys/bin/mapdl", False),
+]
+
+mechanical_executable_paths = [
+    ("C:\\Program Files\\ANSYS Inc\\v221\\aisol\\Bin\\winx64\\ANSYSWBU.exe", True),
+    ("C:/Program Files/ANSYS Inc/v221/aisol/Bin/winx64/ANSYSWBU.exe", True),
+]
 
 skip_if_ansys_not_local = pytest.mark.skipif(
     os.environ.get("ANSYS_LOCAL", "").upper() != "TRUE", reason="Skipping on CI"
@@ -107,3 +120,18 @@ def test_warn_uncommon_executable_path():
 def test_get_mapdl_path():
     assert get_mapdl_path()
     assert get_mapdl_path(version=222)
+
+
+@pytest.fixture
+def mock_is_valid_executable_path(monkeypatch):
+    monkeypatch.setattr("ansys.tools.path.path.is_valid_executable_path", lambda _1, _2: True)
+
+
+@pytest.mark.parametrize("path,expected", mapdl_executable_paths)
+def test_is_common_executable_path_mapdl(mock_is_valid_executable_path, path, expected):
+    assert _is_common_executable_path("mapdl", path) == expected
+
+
+@pytest.mark.parametrize("path,expected", mechanical_executable_paths)
+def test_is_common_executable_path_mechanical(mock_is_valid_executable_path, path, expected):
+    assert _is_common_executable_path("mechanical", path) == expected


### PR DESCRIPTION
* fix #53 
* simplify code of `_is_common_executable_path`
  * remove redundancy of [L401](https://github.com/ansys/ansys-tools-path/pull/55/files#diff-2578fa36965eb52a2a2edeef192d6f3902e611ef7916bc7a56b3e6bb4aac529eL401) because if [re.search(r"v(\d\d\d)", exe_loc) is not None](https://github.com/ansys/ansys-tools-path/pull/55/files#diff-2578fa36965eb52a2a2edeef192d6f3902e611ef7916bc7a56b3e6bb4aac529eL390) then the expression L401 is True
  * For mechanical, transform implicit boolean check [L415](https://github.com/ansys/ansys-tools-path/pull/55/files#diff-2578fa36965eb52a2a2edeef192d6f3902e611ef7916bc7a56b3e6bb4aac529eL415) & [L424](https://github.com/ansys/ansys-tools-path/pull/55/files#diff-2578fa36965eb52a2a2edeef192d6f3902e611ef7916bc7a56b3e6bb4aac529eL424) into an explicit boolean value
  * Remove branches inside "mapdl" section
* add tests
  
