### PR TITLE
Fixing error when config file is empty

### DIFF
--- a/src/ansys/tools/path/path.py
+++ b/src/ansys/tools/path/path.py
@@ -683,7 +683,7 @@ def _read_config_file(product_name: str) -> Dict[str, str]:
             content = f.read()
 
         if content:
-            return json.load(content)
+            return json.loads(content)
 
     return {}
 

--- a/src/ansys/tools/path/path.py
+++ b/src/ansys/tools/path/path.py
@@ -728,7 +728,7 @@ def _get_application_path(
         exe_loc = _read_executable_path_from_config_file(product)
         if exe_loc is not None:
             return exe_loc
-    
+
     try:
         exe_loc, exe_version = _find_installation(product, version)
         if (exe_loc, exe_version) != ("", ""):  # executable not found

--- a/src/ansys/tools/path/path.py
+++ b/src/ansys/tools/path/path.py
@@ -111,7 +111,7 @@ def _get_default_linux_base_path():
 def _get_default_windows_base_path():  # pragma: no cover
     """Get the default base path of the Ansys unified install on windows."""
 
-    base_path = os.path.join(os.environ["PROGRAMFILES"], "ANSYS INC")
+    base_path = os.path.join(os.environ["PROGRAMFILES"], "ANSYS Inc")
     if not os.path.exists(base_path):
         LOG.debug(f"The supposed 'base_path'{base_path} does not exist. No available ansys found.")
         return None
@@ -680,9 +680,12 @@ def _read_config_file(product_name: str) -> Dict[str, str]:
         _migrate_config_file(product_name)
     if os.path.isfile(CONFIG_FILE):
         with open(CONFIG_FILE, "r") as f:
+            content = f.read()
+
+        if content:
             return json.load(f)
-    else:
-        return {}
+
+    return {}
 
 
 def _write_config_file(config_data: Dict[str, str]):
@@ -725,15 +728,15 @@ def _get_application_path(
         exe_loc = _read_executable_path_from_config_file(product)
         if exe_loc is not None:
             return exe_loc
-    else:
-        try:
-            exe_loc, exe_version = _find_installation(product, version)
-            if (exe_loc, exe_version) != ("", ""):  # executable not found
-                if os.path.isfile(exe_loc):
-                    return exe_loc
-        except ValueError:
-            # Skip to go out of the if statement
-            pass
+    
+    try:
+        exe_loc, exe_version = _find_installation(product, version)
+        if (exe_loc, exe_version) != ("", ""):  # executable not found
+            if os.path.isfile(exe_loc):
+                return exe_loc
+    except ValueError:
+        # Skip to go out of the if statement
+        pass
 
     if allow_input:
         exe_loc = _prompt_path(product)
@@ -763,7 +766,7 @@ def get_ansys_path(allow_input: bool = True, version: Optional[float] = None) ->
     """Deprecated, use `get_mapdl_path` instead"""
 
     warnings.warn(
-        "This method is going to be deprecated in future versions. Please use 'get_ansys_path'.",
+        "This method is going to be deprecated in future versions. Please use 'get_mapdl_path'.",
         category=DeprecationWarning,
     )
     return _get_application_path("mapdl", allow_input, version)

--- a/src/ansys/tools/path/path.py
+++ b/src/ansys/tools/path/path.py
@@ -683,7 +683,7 @@ def _read_config_file(product_name: str) -> Dict[str, str]:
             content = f.read()
 
         if content:
-            return json.load(f)
+            return json.load(content)
 
     return {}
 

--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -84,6 +84,7 @@ def mock_filesystem_with_config(mock_filesystem):
         )
     return mock_filesystem
 
+
 @pytest.fixture
 def mock_filesystem_with_empty_config(mock_filesystem):
     config_location = os.path.join(

--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -84,6 +84,16 @@ def mock_filesystem_with_config(mock_filesystem):
         )
     return mock_filesystem
 
+@pytest.fixture
+def mock_filesystem_with_empty_config(mock_filesystem):
+    config_location = os.path.join(
+        platformdirs.user_data_dir(appname="ansys_tools_path", appauthor="Ansys"), "config.txt"
+    )
+    mock_filesystem.create_file(config_location)
+    with open(config_location, "w") as config_file:
+        config_file.write("")
+    return mock_filesystem
+
 
 @pytest.fixture
 def mock_filesystem_without_executable(fs):
@@ -283,3 +293,7 @@ def test_version_from_path(mock_filesystem):
 def test_get_latest_ansys_installation_empty_fs(mock_empty_filesystem):
     with pytest.raises(ValueError):
         get_latest_ansys_installation()
+
+
+def test_empty_config_file(mock_filesystem_with_empty_config):
+    assert get_ansys_path() == LATEST_MAPDL_INSTALL_PATH


### PR DESCRIPTION
Close #68 

Also:
* Fixed a typo on the default ANSYS windows path.
* Not scaping early `_get_application_path` if no version is given and there is none in the config file.