### PR TITLE
remove support for python 3.7

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
         # Only perform wheelhouse builds for macOS when releasing
         should-release:
           - ${{ github.event_name == 'push' && contains(github.ref, 'refs/tags') }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ name = "ansys-tools-path"
 version = "0.3.dev0"
 description = "Library to locate Ansys products in a local machine."
 readme = "README.rst"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 license = {file = "LICENSE"}
 authors = [
     {name = "ANSYS, Inc.", email = "pyansys.core@ansys.com"},
@@ -19,7 +19,6 @@ maintainers = [
 
 classifiers = [
     "Development Status :: 4 - Beta",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
@@ -28,7 +27,6 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "importlib-metadata >=4.0",
     "platformdirs>=3.6.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ name = "ansys-tools-path"
 version = "0.3.dev0"
 description = "Library to locate Ansys products in a local machine."
 readme = "README.rst"
-requires-python = ">=3.8"
+requires-python = ">=3.8,<4"
 license = {file = "LICENSE"}
 authors = [
     {name = "ANSYS, Inc.", email = "pyansys.core@ansys.com"},

--- a/src/ansys/tools/path/path.py
+++ b/src/ansys/tools/path/path.py
@@ -3,7 +3,7 @@ import json
 import logging as LOG  # Temporal hack
 import os
 import re
-from typing import Dict, Literal, Optional, Tuple
+from typing import Dict, Literal, Optional, Tuple, Union
 import warnings
 
 import platformdirs
@@ -222,7 +222,7 @@ def get_available_ansys_installations(
 
 
 def _get_unified_install_base_for_version(
-    version: Optional[int | float] = None,
+    version: Optional[Union[int, float]] = None,
     supported_versions: SUPPORTED_VERSIONS_TYPE = SUPPORTED_ANSYS_VERSIONS,
 ) -> Tuple[str, str]:
     """Search for the unified install of a given version from the supported versions.
@@ -257,7 +257,7 @@ def _get_unified_install_base_for_version(
 def find_mechanical(
     version: Optional[float] = None,
     supported_versions: SUPPORTED_VERSIONS_TYPE = SUPPORTED_ANSYS_VERSIONS,
-) -> Tuple[str, float] | Tuple[Literal[""], Literal[""]]:
+) -> Union[Tuple[str, float], Tuple[Literal[""], Literal[""]]]:
     """
     Search for the Mechanical path in the standard installation location.
 
@@ -293,9 +293,9 @@ def find_mechanical(
 
 
 def find_mapdl(
-    version: Optional[int | float] = None,
+    version: Optional[Union[int, float]] = None,
     supported_versions: SUPPORTED_VERSIONS_TYPE = SUPPORTED_ANSYS_VERSIONS,
-) -> Tuple[str, float | str]:
+) -> Tuple[str, Union[float, str]]:
     """Searches for Ansys MAPDL path within the standard install location
     and returns the path of the latest version.
 


### PR DESCRIPTION
fix #71 

- remove support for python 3.7
- remove importlib-metadata from dependencies as it was not used and is useless for python 3.8+