### PR TITLE
remove importlib-metadata

### DIFF
--- a/src/ansys/tools/path/__init__.py
+++ b/src/ansys/tools/path/__init__.py
@@ -4,10 +4,7 @@ tools to find/cache installed Ansys products.
 WARNING: This is not concurrent-safe (multiple python processes might race on this data.)
 """
 
-try:
-    import importlib.metadata as importlib_metadata
-except ModuleNotFoundError:
-    import importlib_metadata
+import importlib.metadata as importlib_metadata
 
 __version__ = importlib_metadata.version(__name__.replace(".", "-"))
 

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -4,10 +4,7 @@ from ansys.tools.path import __version__
 
 
 def test_pkg_version():
-    try:
-        import importlib.metadata as importlib_metadata
-    except ModuleNotFoundError:  # pragma: no cover
-        import importlib_metadata
+    import importlib.metadata as importlib_metadata
 
     # Read from the pyproject.toml
     # major, minor, patch


### PR DESCRIPTION
remove import of `importlib_metadata` as it is no more used (the library is a backport of importlib.metadata for python <=3.7)