### PR TITLE
feat: bump version on main

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "flit_core.buildapi"
 [project]
 # Check https://flit.readthedocs.io/en/latest/pyproject_toml.html for all available sections
 name = "ansys-tools-path"
-version = "0.3.dev0"
+version = "0.4.dev0"
 description = "Library to locate Ansys products in a local machine."
 readme = "README.rst"
 requires-python = ">=3.8,<4"


### PR DESCRIPTION
Looks like #85 identified this issue. Always keep ahead by 1 from the latest minor released version on main