### PR TITLE
support any application with save-ansys-path

### DIFF
--- a/src/ansys/tools/path/applications/__init__.py
+++ b/src/ansys/tools/path/applications/__init__.py
@@ -1,0 +1,12 @@
+"""
+Application plugin for ansys-tools-path.
+
+This defines the interface of a plugin, which is implemented using a module.
+"""
+
+# TODO - consider using pluggy?
+
+
+class ApplicationPlugin:
+    def is_valid_executable_path(exe_loc: str) -> bool:
+        raise Exception("This is just a base class.")

--- a/src/ansys/tools/path/applications/dyna.py
+++ b/src/ansys/tools/path/applications/dyna.py
@@ -1,0 +1,28 @@
+# Copyright (C) 2023 ANSYS, Inc. and/or its affiliates.
+# SPDX-License-Identifier: MIT
+#
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""dyna-specific logic for ansys-tools-path."""
+
+
+def is_valid_executable_path(exe_loc: str) -> bool:
+    # dyna paths can be anything
+    return True

--- a/src/ansys/tools/path/applications/mapdl.py
+++ b/src/ansys/tools/path/applications/mapdl.py
@@ -1,0 +1,33 @@
+# Copyright (C) 2023 ANSYS, Inc. and/or its affiliates.
+# SPDX-License-Identifier: MIT
+#
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""MAPDL-specific logic for ansys-tools-path."""
+
+import os
+import re
+
+
+def is_valid_executable_path(exe_loc: str) -> bool:
+    return (
+        os.path.isfile(exe_loc)
+        and re.search(r"ansys\d\d\d", os.path.basename(os.path.normpath(exe_loc))) is not None
+    )

--- a/src/ansys/tools/path/applications/mechanical.py
+++ b/src/ansys/tools/path/applications/mechanical.py
@@ -1,0 +1,43 @@
+# Copyright (C) 2023 ANSYS, Inc. and/or its affiliates.
+# SPDX-License-Identifier: MIT
+#
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Mechanical-specific logic for ansys-tools-path."""
+
+import os
+import re
+
+from ansys.tools.path.misc import is_windows
+
+
+def is_valid_executable_path(exe_loc: str) -> bool:
+    if is_windows():  # pragma: no cover
+        return (
+            os.path.isfile(exe_loc)
+            and re.search(
+                "AnsysWBU.exe", os.path.basename(os.path.normpath(exe_loc)), re.IGNORECASE
+            )
+            is not None
+        )
+    return (
+        os.path.isfile(exe_loc)
+        and re.search(".workbench", os.path.basename(os.path.normpath(exe_loc))) is not None
+    )


### PR DESCRIPTION
Allow saving any path, not just well-known paths using ansys-tools-path. I want to use this for another program that doesn't belong to any installation (it uses a portable install) and has no version number (it is versioned independently from the likes of mapdl, mechanical, etc).

Obviously the features to find the location and get the version of the application would not work, but I just want to use `save-ansys-path` to store it and to get the path in the python client of that other program.

I tested this locally using 7zip, like this:

```
$ save-ansys-path --name=7z "C:\path\to\7-Zip\7zG.exe"
$ python
>>> from ansys.tools.path.path import _get_application_path
>>> _get_application_path("7z")
'C:\\path\\to\\7-Zip\\7zG.exe'
```

As an implementation detail, I added a simple plugin-system for the "supported" applications (dyna, mapdl, mechanical). I didn't migrate much there, but I think we should move app-specific code there for better maintenance going forwards.
