### PR TITLE
Feat: Add option to check saved path matches with arg version

### DIFF
--- a/src/ansys/tools/path/path.py
+++ b/src/ansys/tools/path/path.py
@@ -944,17 +944,17 @@ def _get_application_path(
     find: bool = True,
 ) -> Optional[str]:
     _exe_loc = _read_executable_path_from_config_file(product)
-    if version is None and _exe_loc is not None:
-        return _exe_loc
-    else:
-        if _exe_loc is not None:
+    if _exe_loc is not None:
+        if version is None:
+            return _exe_loc
+        else:
             _version = version_from_path(product, _exe_loc)
             if _version == version:
                 return _exe_loc
             else:
                 LOG.debug(
                     f"Application {product} requested version {version} does not match with {_version} "
-                    f"in config file. Trying to find version {version} in system ..."
+                    f"in config file. Trying to find version {version} ..."
                 )
 
     LOG.debug(f"{product} path not found in config file")

--- a/src/ansys/tools/path/path.py
+++ b/src/ansys/tools/path/path.py
@@ -945,8 +945,8 @@ def _get_application_path(
 ) -> Optional[str]:
 
     _exe_loc = _read_executable_path_from_config_file(product)
-    _version = version_from_path("mechanical", _exe_loc)
     if _exe_loc is not None:
+        _version = version_from_path("mechanical", _exe_loc)
         if _version == version:
             return _exe_loc
         else:

--- a/src/ansys/tools/path/path.py
+++ b/src/ansys/tools/path/path.py
@@ -943,10 +943,17 @@ def _get_application_path(
     version: Optional[float] = None,
     find: bool = True,
 ) -> Optional[str]:
-    if version is None:
-        exe_loc = _read_executable_path_from_config_file(product)
-        if exe_loc is not None:
-            return exe_loc
+
+    _exe_loc = _read_executable_path_from_config_file(product)
+    _version = version_from_path("mechanical", _exe_loc)
+    if _exe_loc is not None:
+        if _version == version:
+            return _exe_loc
+        else:
+            LOG.debug(
+                f"Application {product} requested version {version} does not match with {_version} "
+                f"in config file. Trying to find version {version} in system ..."
+            )
 
     LOG.debug(f"{product} path not found in config file")
     if not _has_plugin(product):

--- a/src/ansys/tools/path/path.py
+++ b/src/ansys/tools/path/path.py
@@ -943,17 +943,19 @@ def _get_application_path(
     version: Optional[float] = None,
     find: bool = True,
 ) -> Optional[str]:
-
     _exe_loc = _read_executable_path_from_config_file(product)
-    if _exe_loc is not None:
-        _version = version_from_path("mechanical", _exe_loc)
-        if _version == version:
-            return _exe_loc
-        else:
-            LOG.debug(
-                f"Application {product} requested version {version} does not match with {_version} "
-                f"in config file. Trying to find version {version} in system ..."
-            )
+    if version is None and _exe_loc is not None:
+        return _exe_loc
+    else:
+        if _exe_loc is not None:
+            _version = version_from_path(product, _exe_loc)
+            if _version == version:
+                return _exe_loc
+            else:
+                LOG.debug(
+                    f"Application {product} requested version {version} does not match with {_version} "
+                    f"in config file. Trying to find version {version} in system ..."
+                )
 
     LOG.debug(f"{product} path not found in config file")
     if not _has_plugin(product):


### PR DESCRIPTION
if get_mechanical_path(version=232)  has version provided. check saved path first, if version not found there then use find mechancial

@koubaa Should this be a debug or warning if version mismatch between saved path and requested ?