### PR TITLE
fix: add an exception if executable not found

### DIFF
--- a/src/ansys/tools/path/path.py
+++ b/src/ansys/tools/path/path.py
@@ -967,8 +967,6 @@ def _get_application_path(
             if (exe_loc, exe_version) != ("", ""):  # executable not found
                 if os.path.isfile(exe_loc):
                     return exe_loc
-            else:
-                raise Exception("{product} executable not found in default locations")
         except ValueError:
             # Skip to go out of the if statement
             pass
@@ -1133,6 +1131,8 @@ def version_from_path(product: PRODUCT_TYPE, path: str) -> int:
         Integer version number (for example, 231).
 
     """
+    if not isinstance(path, str):
+        raise ValueError("Provided path is not a string")
     if product == "mechanical":
         return _mechanical_version_from_path(path)
     elif product == "mapdl":

--- a/src/ansys/tools/path/path.py
+++ b/src/ansys/tools/path/path.py
@@ -967,6 +967,8 @@ def _get_application_path(
             if (exe_loc, exe_version) != ("", ""):  # executable not found
                 if os.path.isfile(exe_loc):
                     return exe_loc
+            else:
+                raise Exception("{product} executable not found in default locations")
         except ValueError:
             # Skip to go out of the if statement
             pass

--- a/src/ansys/tools/path/path.py
+++ b/src/ansys/tools/path/path.py
@@ -1133,7 +1133,7 @@ def version_from_path(product: PRODUCT_TYPE, path: str) -> int:
 
     """
     if not isinstance(path, str):
-        raise ValueError("Provided path is not a string")
+        raise ValueError(f"Provided path '{path}' is not a string.")
     if product == "mechanical":
         return _mechanical_version_from_path(path)
     elif product == "mapdl":


### PR DESCRIPTION
Currently, if no executable found in default location when using `get_mechanical_path` , then we are returning `None`. This is causing issue when we call `version_from_path` where we give `path` as input. We do not have any check if path is None. 

Alternately we can avoid this exception and return `path` as empty string (as it is) it is instead of `None`. If that is the case then  `version_from_path` will take care of value error if `path` is `empty string`

