### PR TITLE
FIX: Update error handling for path

### DIFF
--- a/src/ansys/tools/path/path.py
+++ b/src/ansys/tools/path/path.py
@@ -1157,9 +1157,9 @@ def version_from_path(product: PRODUCT_TYPE, path: str) -> int:
     """
     if not isinstance(path, str):
         raise ValueError(
-            f"Provided path '{path}' is not valid string."
-            f"Check if the {product} is installed in default location."
-            f"If not use ``save-ansys-path`` to save the path."
+            f'The provided path, "{path}", is not a valid string.'
+            f'If "{product}" is not installed in the default location, use ``save-ansys-path``'
+            f"to save the path so it can be found by ``ansys-tools-path``."
         )
     if product == "mechanical":
         return _mechanical_version_from_path(path)

--- a/src/ansys/tools/path/path.py
+++ b/src/ansys/tools/path/path.py
@@ -999,7 +999,7 @@ def _get_application_path(
         exe_loc = _prompt_path(product)
         _change_default_path(product, exe_loc)
         return exe_loc
-    warnings.warn(f"No path found for {product} in default locations")
+    warnings.warn(f"No path found for {product} in default locations.")
     return None
 
 

--- a/src/ansys/tools/path/path.py
+++ b/src/ansys/tools/path/path.py
@@ -1157,9 +1157,9 @@ def version_from_path(product: PRODUCT_TYPE, path: str) -> int:
     """
     if not isinstance(path, str):
         raise ValueError(
-            f"Provided path '{path}' is not valid string. "
-            "Check if the {product} is installed in default location. "
-            "If not use ``save-ansys-path`` to save the path."
+            f"Provided path '{path}' is not valid string."
+            f"Check if the {product} is installed in default location."
+            f"If not use ``save-ansys-path`` to save the path."
         )
     if product == "mechanical":
         return _mechanical_version_from_path(path)

--- a/src/ansys/tools/path/path.py
+++ b/src/ansys/tools/path/path.py
@@ -1157,8 +1157,8 @@ def version_from_path(product: PRODUCT_TYPE, path: str) -> int:
     """
     if not isinstance(path, str):
         raise ValueError(
-            f'The provided path, "{path}", is not a valid string.'
-            f'If "{product}" is not installed in the default location, use ``save-ansys-path``'
+            f'The provided path, "{path}", is not a valid string. '
+            f'If "{product}" is not installed in the default location, use ``save-ansys-path`` '
             f"to save the path so it can be found by ``ansys-tools-path``."
         )
     if product == "mechanical":

--- a/src/ansys/tools/path/path.py
+++ b/src/ansys/tools/path/path.py
@@ -1109,8 +1109,6 @@ def _mechanical_version_from_path(path: str) -> int:
     """
     # expect v<ver>/ansys
     # replace \\ with / to account for possible windows path
-    if path is None:
-        raise Exception("Path is None")
     matches = re.findall(r"v(\d\d\d)", path.replace("\\", "/"), re.IGNORECASE)
     if not matches:
         raise RuntimeError(f"Unable to extract Mechanical version from {path}.")
@@ -1159,9 +1157,9 @@ def version_from_path(product: PRODUCT_TYPE, path: str) -> int:
     """
     if not isinstance(path, str):
         raise ValueError(
-            f"Provided path '{path}' is not valid string."
-            "Check if the {product} is installed in default location"
-            "If not use 'save-ansys-path' to save the path."
+            f"Provided path '{path}' is not valid string. "
+            "Check if the {product} is installed in default location. "
+            "If not use ``save-ansys-path`` to save the path."
         )
     if product == "mechanical":
         return _mechanical_version_from_path(path)

--- a/src/ansys/tools/path/path.py
+++ b/src/ansys/tools/path/path.py
@@ -999,7 +999,7 @@ def _get_application_path(
         exe_loc = _prompt_path(product)
         _change_default_path(product, exe_loc)
         return exe_loc
-
+    warnings.warn(f"No path found for {product} in default locations")
     return None
 
 
@@ -1109,6 +1109,8 @@ def _mechanical_version_from_path(path: str) -> int:
     """
     # expect v<ver>/ansys
     # replace \\ with / to account for possible windows path
+    if path is None:
+        raise Exception("Path is None")
     matches = re.findall(r"v(\d\d\d)", path.replace("\\", "/"), re.IGNORECASE)
     if not matches:
         raise RuntimeError(f"Unable to extract Mechanical version from {path}.")
@@ -1156,7 +1158,11 @@ def version_from_path(product: PRODUCT_TYPE, path: str) -> int:
 
     """
     if not isinstance(path, str):
-        raise ValueError(f"Provided path '{path}' is not a string.")
+        raise ValueError(
+            f"Provided path '{path}' is not valid string."
+            "Check if the {product} is installed in default location"
+            "If not use 'save-ansys-path' to save the path."
+        )
     if product == "mechanical":
         return _mechanical_version_from_path(path)
     elif product == "mapdl":


### PR DESCRIPTION
Currently no user friendly error is thrown when the path is not found in default locations.

Related to https://github.com/ansys/pymechanical-env/issues/70

Current
```
    matches = re.findall(r"v(\d\d\d)", path.replace("\\", "/"), re.IGNORECASE)
AttributeError: 'NoneType' object has no attribute 'replace'

```
Updated handling.

```
ValueError: The provided path, "None", is not a valid string. If "mechanical" is not installed in the default location, use ``save-ansys-path`` to save the path so it can be found by ``ansys-tools-path``.

```

