### PR TITLE
ci: pin `ubuntu-22.04` for build-tests step

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -45,10 +45,10 @@ jobs:
 
   build-tests:
     name: Build and Testing
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [smoke-tests]
     container:
-      image: ghcr.io/ansys/pymapdl/mapdl:v24.1-ubuntu
+      image: ghcr.io/ansys/pymapdl/mapdl:v22.2-ubuntu
       options: "-u=0:0 --entrypoint /bin/bash"
       credentials:
         username: ${{ secrets.GH_USERNAME }}

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [smoke-tests]
     container:
-      image: ghcr.io/ansys/pymapdl/mapdl:v25.1-ubuntu
+      image: ghcr.io/ansys/pymapdl/mapdl:v24.1-ubuntu
       options: "-u=0:0 --entrypoint /bin/bash"
       credentials:
         username: ${{ secrets.GH_USERNAME }}

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [smoke-tests]
     container:
-      image: ghcr.io/ansys/pymapdl/mapdl:v22.2-ubuntu
+      image: ghcr.io/ansys/pymapdl/mapdl:v25.1-ubuntu
       options: "-u=0:0 --entrypoint /bin/bash"
       credentials:
         username: ${{ secrets.GH_USERNAME }}

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+Copyright (c) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/src/ansys/tools/path/__init__.py
+++ b/src/ansys/tools/path/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/tools/path/applications/__init__.py
+++ b/src/ansys/tools/path/applications/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/tools/path/applications/dyna.py
+++ b/src/ansys/tools/path/applications/dyna.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/tools/path/applications/mapdl.py
+++ b/src/ansys/tools/path/applications/mapdl.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/tools/path/applications/mechanical.py
+++ b/src/ansys/tools/path/applications/mechanical.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/tools/path/misc.py
+++ b/src/ansys/tools/path/misc.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/tools/path/path.py
+++ b/src/ansys/tools/path/path.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/tools/path/save.py
+++ b/src/ansys/tools/path/save.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -59,15 +59,15 @@ def test_save_mapdl_path():
         with open(CONFIG_FILE, "r") as config_file:
             old_config = config_file.read()
 
-    path, _ = find_mapdl(version=251)
+    path, _ = find_mapdl(version=241)
 
     assert save_mapdl_path(path, allow_prompt=False)
     with open(CONFIG_FILE, "r") as config_file:
-        assert json.loads(config_file.read()) == {"mapdl": "/ansys_inc/v251/ansys/bin/ansys251"}
+        assert json.loads(config_file.read()) == {"mapdl": "/ansys_inc/v241/ansys/bin/ansys241"}
 
     assert save_mapdl_path(None, allow_prompt=False)
     with open(CONFIG_FILE, "r") as config_file:
-        assert json.loads(config_file.read()) == {"mapdl": "/ansys_inc/v251/ansys/bin/ansys251"}
+        assert json.loads(config_file.read()) == {"mapdl": "/ansys_inc/v241/ansys/bin/ansys241"}
     clear_configuration("all")
     if old_config is not None:
         with open(CONFIG_FILE, "w") as config_file:

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -59,15 +59,15 @@ def test_save_mapdl_path():
         with open(CONFIG_FILE, "r") as config_file:
             old_config = config_file.read()
 
-    path, _ = find_mapdl(version=241)
+    path, _ = find_mapdl(version=222)
 
     assert save_mapdl_path(path, allow_prompt=False)
     with open(CONFIG_FILE, "r") as config_file:
-        assert json.loads(config_file.read()) == {"mapdl": "/ansys_inc/v241/ansys/bin/ansys241"}
+        assert json.loads(config_file.read()) == {"mapdl": "/ansys_inc/v222/ansys/bin/ansys222"}
 
     assert save_mapdl_path(None, allow_prompt=False)
     with open(CONFIG_FILE, "r") as config_file:
-        assert json.loads(config_file.read()) == {"mapdl": "/ansys_inc/v241/ansys/bin/ansys241"}
+        assert json.loads(config_file.read()) == {"mapdl": "/ansys_inc/v222/ansys/bin/ansys222"}
     clear_configuration("all")
     if old_config is not None:
         with open(CONFIG_FILE, "w") as config_file:

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #
@@ -59,15 +59,15 @@ def test_save_mapdl_path():
         with open(CONFIG_FILE, "r") as config_file:
             old_config = config_file.read()
 
-    path, _ = find_mapdl(version=222)
+    path, _ = find_mapdl(version=251)
 
     assert save_mapdl_path(path, allow_prompt=False)
     with open(CONFIG_FILE, "r") as config_file:
-        assert json.loads(config_file.read()) == {"mapdl": "/ansys_inc/v222/ansys/bin/ansys222"}
+        assert json.loads(config_file.read()) == {"mapdl": "/ansys_inc/v251/ansys/bin/ansys251"}
 
     assert save_mapdl_path(None, allow_prompt=False)
     with open(CONFIG_FILE, "r") as config_file:
-        assert json.loads(config_file.read()) == {"mapdl": "/ansys_inc/v222/ansys/bin/ansys222"}
+        assert json.loads(config_file.read()) == {"mapdl": "/ansys_inc/v251/ansys/bin/ansys251"}
     clear_configuration("all")
     if old_config is not None:
         with open(CONFIG_FILE, "w") as config_file:

--- a/tests/unit/test_metadata.py
+++ b/tests/unit/test_metadata.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/unit/test_misc.py
+++ b/tests/unit/test_misc.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/unit/test_path.py
+++ b/tests/unit/test_path.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #


### PR DESCRIPTION
Change `ubuntu-latest` to `ubuntu-22.04` for the build-tests step since it uses `ghcr.io/ansys/pymapdl/mapdl:v22.2-ubuntu`

See https://github.com/ansys/pymapdl/pull/3659