### PR TITLE
ci: update ci_cd.yml to use ubuntu latest

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -45,7 +45,7 @@ jobs:
 
   build-tests:
     name: Build and Testing
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: [smoke-tests]
     container:
       image: ghcr.io/ansys/pymapdl/mapdl:v22.2-ubuntu


### PR DESCRIPTION
Following the changes performed in https://github.com/ansys/ansys-tools-path/pull/268, this PRs applies a change that will be required soon since https://github.com/ansys/pymapdl/pull/3814 is going to be merged.