### PR TITLE
ci: update mapdl docker image

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -62,7 +62,7 @@ jobs:
     runs-on: ubuntu-22.04
     needs: [smoke-tests]
     container:
-      image: ghcr.io/ansys/pymapdl/mapdl:v22.2-ubuntu
+      image: ghcr.io/ansys/mapdl:v22.2-ubuntu
       options: "-u=0:0 --entrypoint /bin/bash"
       credentials:
         username: ${{ secrets.GH_USERNAME }}

--- a/doc/changelog.d/315.maintenance.md
+++ b/doc/changelog.d/315.maintenance.md
@@ -1,0 +1,1 @@
+Update mapdl docker image


### PR DESCRIPTION
The package `ansys/pymapdl/mapdl` is going to be deprecated. The replacement is `ansys/mapdl`.